### PR TITLE
Fix multiline align imports

### DIFF
--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -4,6 +4,24 @@ const rule = require('./rules/align-imports');
 
 ruleTester.run('AlignImports', rule, {
     valid: [
+        {
+            code: `
+import '/imports/api/balances';`,
+        },
+        {
+            code: `
+import '/imports/api/treeNodes/tests/renameNodesFromReference.meteor-test';
+import '/imports/api/treeNodes/tests/pasteTreeNode.meteor-test';
+import '/imports/api/treeNodes/tests/cloneTreeNode.meteor-test';
+import '/imports/api/users/tests/ensureCanManageUser.meteor-test';
+import '/imports/api/properties/values/static.resolveRawPropertyValue.meteor-test';
+import '/imports/api/properties/values/static.validatePropertyValues.meteor-test';
+import '/imports/api/properties/values/static.alignPropertyValuesToOptions.meteor-test';
+import '/imports/api/workinstructions/bundle/static.getWorkinstructionBundle.meteor-test';
+import '/imports/api/workinstructions/bundle/static.bundleBalanceWorker.meteor-test';
+import '/imports/api/workinstructions/bundle/static.bundleResources.meteor-test';
+import '/imports/api/workinstructions/server/copyWorkinstruction.meteor-test';`
+        },
         // don't modify what can stay on one line
         {
             code: `

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -68,6 +68,31 @@ import Deft, {
     cItemLonger1,
 }                                       from 'd';`
         },
+        {
+            code:
+                `
+import * as security                    from '/imports/api/security';`
+        },
+        {
+            code:
+                `
+import * as securityVeryLonsdfsdfdsfsdfsdfsdf from '/imports/api/security';`,
+        },
+        {
+            code:
+                `
+import * as securityVeryLonsdfsdfdsfsda from '/imports/api/security';`,
+        },
+        {
+            code:
+                `
+import * as securityVeryLonsdfsdfdsfsd  from '/imports/api/security';`,
+        },
+        {
+            code:
+                `
+import * as securityVeryLonsdfsdfdsfsdab from '/imports/api/security';`,
+        },
     ],
     invalid: [
         {
@@ -336,6 +361,42 @@ import Deft, {
     bItemLonger1,
     cItemLonger1,
 }                                       from 'd';`
+        },
+        {
+            code:
+                `
+import * as security                  from '/imports/api/security';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import * as security                    from '/imports/api/security';`
+        },
+        {
+            code:
+                `
+import * as securityVeryLonsdfsdfdsfsda        from '/imports/api/security';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import * as securityVeryLonsdfsdfdsfsda from '/imports/api/security';`
+        },
+        {
+            code:
+                `
+import * as securityVeryLonsdfsdfdsfsd from '/imports/api/security';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import * as securityVeryLonsdfsdfdsfsd  from '/imports/api/security';`
+        },
+        {
+            code:
+                `
+import * as securityVeryLonsdfsdfdsfsdab     from '/imports/api/security';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import * as securityVeryLonsdfsdfdsfsdab from '/imports/api/security';`
         },
     ]
 });

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -16,7 +16,7 @@ import {
     JumpToTarget,
     Rule,
     RuleType2,
-} from 'common/api/rules';`,
+}                                       from 'common/api/rules';`,
         },
         // don't modify what can't stay on one line (corner case, with default)
         {
@@ -24,7 +24,7 @@ import {
 import JumpToTarget, {
     Rule,
     RuleType2,
-} from 'common/api/rules';`,
+}                                       from 'common/api/rules';`,
         },
         // don't modify what can stay on one line (corner case)
         {
@@ -397,6 +397,19 @@ import * as securityVeryLonsdfsdfdsfsdab     from '/imports/api/security';`,
             output:
                 `
 import * as securityVeryLonsdfsdfdsfsdab from '/imports/api/security';`
+        },
+        {
+            code:
+                `
+import {
+    exportWorkinstructionWithVersion,
+} from '/imports/api/workinstructions/server/export-import/export';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import {
+    exportWorkinstructionWithVersion,
+}                                       from '/imports/api/workinstructions/server/export-import/export';`
         },
     ]
 });

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -4,12 +4,12 @@ const rule = require('./rules/align-imports');
 
 ruleTester.run('AlignImports', rule, {
     valid: [
-        /* don't modify what can stay on one line */
+        // don't modify what can stay on one line
         {
             code: `
 import Balances, { Balance }            from '/imports/api/balances';`,
         },
-        /* don't modify what can't stay on one line (corner case) */
+        // don't modify what can't stay on one line (corner case)
         {
             code: `
 import {
@@ -18,7 +18,7 @@ import {
     RuleType2,
 } from 'common/api/rules';`,
         },
-        /* don't modify what can't stay on one line (corner case, with default) */
+        // don't modify what can't stay on one line (corner case, with default)
         {
             code: `
 import JumpToTarget, {
@@ -26,12 +26,12 @@ import JumpToTarget, {
     RuleType2,
 } from 'common/api/rules';`,
         },
-        /* don't modify what can stay on one line (corner case) */
+        // don't modify what can stay on one line (corner case)
         {
             code: `
 import { JumpToTarget, Rule, RuleType } from 'common/api/rules';`,
         },
-        /* don't modify what can stay on one line (corner case, with default) */
+        // don't modify what can stay on one line (corner case, with default)
         {
             code: `
 import JumpToTarget, { Rule, RuleType } from 'common/api/rules';`,

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -53,5 +53,60 @@ import { expect } from 'chai';`,
                 `
 import { expect }                       from 'chai';`
         },
+        {
+            code: `
+import {
+    createWorkinstruction,
+    originalCompany, setupMain,
+    workinstructionToString, approve, getCreateWorkInstructionArgs, exportWorkinstruction, selectCompany, destinationCompany, actualImportWorkinstruction, rootNodeId, addWorkinstruction, getDefaultContext, importWorkinstruction, getImportContext,
+}                                       from '/imports/api/workinstructions/server/export-import/importExportTestUtility';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import {
+    createWorkinstruction,
+    originalCompany,
+    setupMain,
+    workinstructionToString,
+    approve,
+    getCreateWorkInstructionArgs,
+    exportWorkinstruction,
+    selectCompany,
+    destinationCompany,
+    actualImportWorkinstruction,
+    rootNodeId,
+    addWorkinstruction,
+    getDefaultContext,
+    importWorkinstruction,
+    getImportContext,
+}                                       from '/imports/api/workinstructions/server/export-import/importExportTestUtility';`
+        },
+        {
+            code: `
+import {
+    createWorkinstruction, originalCompany, setupMain,
+    workinstructionToString, approve, getCreateWorkInstructionArgs, exportWorkinstruction, selectCompany, destinationCompany, actualImportWorkinstruction, rootNodeId, addWorkinstruction, getDefaultContext, importWorkinstruction, getImportContext,
+}              from '/imports/api/workinstructions/server/export-import/importExportTestUtility';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import {
+    createWorkinstruction,
+    originalCompany,
+    setupMain,
+    workinstructionToString,
+    approve,
+    getCreateWorkInstructionArgs,
+    exportWorkinstruction,
+    selectCompany,
+    destinationCompany,
+    actualImportWorkinstruction,
+    rootNodeId,
+    addWorkinstruction,
+    getDefaultContext,
+    importWorkinstruction,
+    getImportContext,
+}                                       from '/imports/api/workinstructions/server/export-import/importExportTestUtility';`
+        },
     ]
 });

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -108,5 +108,29 @@ import {
     getImportContext,
 }                                       from '/imports/api/workinstructions/server/export-import/importExportTestUtility';`
         },
+        {
+            code: `
+import {
+  a, 
+}              from 'somefile';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import {
+    a,
+}                                       from 'somefile';`
+        },
+        {
+            code: `
+import 
+  a 
+              from 'somefile';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import {
+    default as a,
+}                                       from 'somefile';`
+        },
     ]
 });

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -93,6 +93,20 @@ import * as securityVeryLonsdfsdfdsfsd  from '/imports/api/security';`,
                 `
 import * as securityVeryLonsdfsdfdsfsdab from '/imports/api/security';`,
         },
+        // don't modify correctly sorted (ignoring cases)
+        {
+            code: `
+import { Bup, aLowercase, cLow }        from 'common/api/rules';`,
+        },
+        {
+            code:
+                `
+import {
+    BupLonger,
+    aLowercaseLonger,
+    cLowLonger,
+}                                       from 'common/api/rules';`
+        },
     ],
     invalid: [
         {
@@ -410,6 +424,28 @@ import {
 import {
     exportWorkinstructionWithVersion,
 }                                       from '/imports/api/workinstructions/server/export-import/export';`
+        },
+        // sort case-sensitively
+        {
+            code: `
+import { aLowercase, Bup, cLow }        from 'common/api/rules';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import { Bup, aLowercase, cLow }        from 'common/api/rules';`
+        },
+        // sort case-sensitively longer imports
+        {
+            code: `
+import { aLowercaseLonger, BupLonger, cLowLonger }         from 'common/api/rules';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import {
+    BupLonger,
+    aLowercaseLonger,
+    cLowLonger,
+}                                       from 'common/api/rules';`
         },
     ]
 });

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -31,6 +31,11 @@ import JumpToTarget, {
             code: `
 import { JumpToTarget, Rule, RuleType } from 'common/api/rules';`,
         },
+        // don't modify what can stay on one line (one spare character)
+        {
+            code: `
+import { JumpToTarget, Rule, RuleTyp }  from 'common/api/rules';`,
+        },
         // don't modify what can stay on one line (corner case, with default)
         {
             code: `
@@ -323,6 +328,18 @@ import {
             output:
                 `
 import { JumpToTarget, Rule, RuleType } from 'common/api/rules';`
+        },
+        // don't modify what can stay on one line (one spare character)
+        {
+            code: `
+import {
+    JumpToTarget,
+    Rule,
+    RuleTyp,
+} from 'common/api/rules';`,
+            errors: [{ line: 2, }],
+            output: `
+import { JumpToTarget, Rule, RuleTyp }  from 'common/api/rules';`,
         },
         // test sorting single line (without default)
         {

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -96,21 +96,21 @@ import {
             output:
                 `
 import {
+    actualImportWorkinstruction,
+    addWorkinstruction,
+    approve,
     createWorkinstruction,
+    destinationCompany,
+    exportWorkinstruction,
+    getCreateWorkInstructionArgs,
+    getDefaultContext,
+    getImportContext,
+    importWorkinstruction,
     originalCompany,
+    rootNodeId,
+    selectCompany,
     setupMain,
     workinstructionToString,
-    approve,
-    getCreateWorkInstructionArgs,
-    exportWorkinstruction,
-    selectCompany,
-    destinationCompany,
-    actualImportWorkinstruction,
-    rootNodeId,
-    addWorkinstruction,
-    getDefaultContext,
-    importWorkinstruction,
-    getImportContext,
 }                                       from '/imports/api/workinstructions/server/export-import/importExportTestUtility';`
         },
         {
@@ -123,21 +123,21 @@ import {
             output:
                 `
 import {
+    actualImportWorkinstruction,
+    addWorkinstruction,
+    approve,
     createWorkinstruction,
+    destinationCompany,
+    exportWorkinstruction,
+    getCreateWorkInstructionArgs,
+    getDefaultContext,
+    getImportContext,
+    importWorkinstruction,
     originalCompany,
+    rootNodeId,
+    selectCompany,
     setupMain,
     workinstructionToString,
-    approve,
-    getCreateWorkInstructionArgs,
-    exportWorkinstruction,
-    selectCompany,
-    destinationCompany,
-    actualImportWorkinstruction,
-    rootNodeId,
-    addWorkinstruction,
-    getDefaultContext,
-    importWorkinstruction,
-    getImportContext,
 }                                       from '/imports/api/workinstructions/server/export-import/importExportTestUtility';`
         },
         {
@@ -172,8 +172,8 @@ import React,
             output:
                 `
 import React, {
-    useMemo,
     useEffect,
+    useMemo,
     useRef,
 }                                       from 'react';`
         },
@@ -219,21 +219,21 @@ import {
 import { expect }                       from 'chai';
 import Balances, { Balance }            from '/imports/api/balances';
 import {
+    actualImportWorkinstruction,
+    addWorkinstruction,
+    approve,
     createWorkinstruction,
+    destinationCompany,
+    exportWorkinstruction,
+    getCreateWorkInstructionArgs,
+    getDefaultContext,
+    getImportContext,
+    importWorkinstruction,
     originalCompany,
+    rootNodeId,
+    selectCompany,
     setupMain,
     workinstructionToString,
-    approve,
-    getCreateWorkInstructionArgs,
-    exportWorkinstruction,
-    selectCompany,
-    destinationCompany,
-    actualImportWorkinstruction,
-    rootNodeId,
-    addWorkinstruction,
-    getDefaultContext,
-    importWorkinstruction,
-    getImportContext,
 }                                       from '/imports/api/workinstructions/server/export-import/importExportTestUtility';
 import { findRequiredBalance }          from '/imports/api/workinstructions/server/export-import/importUtility';
 import uuid_v4                          from '/imports/libs/uuid_v4';

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -4,6 +4,38 @@ const rule = require('./rules/align-imports');
 
 ruleTester.run('AlignImports', rule, {
     valid: [
+        /* don't modify what can stay on one line */
+        {
+            code: `
+import Balances, { Balance }            from '/imports/api/balances';`,
+        },
+        /* don't modify what can't stay on one line (corner case) */
+        {
+            code: `
+import {
+    JumpToTarget,
+    Rule,
+    RuleType2,
+} from 'common/api/rules';`,
+        },
+        /* don't modify what can't stay on one line (corner case, with default) */
+        {
+            code: `
+import JumpToTarget, {
+    Rule,
+    RuleType2,
+} from 'common/api/rules';`,
+        },
+        /* don't modify what can stay on one line (corner case) */
+        {
+            code: `
+import { JumpToTarget, Rule, RuleType } from 'common/api/rules';`,
+        },
+        /* don't modify what can stay on one line (corner case, with default) */
+        {
+            code: `
+import JumpToTarget, { Rule, RuleType } from 'common/api/rules';`,
+        },
     ],
     invalid: [
         {
@@ -116,9 +148,7 @@ import {
             errors: [{ line: 2, }],
             output:
                 `
-import {
-    a,
-}                                       from 'somefile';`
+import { a }                            from 'somefile';`
         },
         {
             code: `
@@ -128,9 +158,24 @@ import
             errors: [{ line: 2, }],
             output:
                 `
-import {
-    default as a,
-}                                       from 'somefile';`
+import a                                from 'somefile';`
+        },
+        {
+            code: `
+import React,
+{
+    useMemo,
+    useEffect,
+    useRef,
+}                                       from 'react';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import React, {
+    useMemo,
+    useEffect,
+    useRef,
+}                                       from 'react';`
         },
         {
             code: `
@@ -194,11 +239,19 @@ import { findRequiredBalance }          from '/imports/api/workinstructions/serv
 import uuid_v4                          from '/imports/libs/uuid_v4';
 import { getMasterBalance }             from '/imports/rest/v1/workinstructions/util';
 import { Action }                       from 'common/api/exportImport/importContext';
+import { JumpToTarget, Rule, RuleType } from 'common/api/rules';`
+        },
+        {
+            code: `
 import {
     JumpToTarget,
     Rule,
     RuleType,
-}                                       from 'common/api/rules';`
+} from 'common/api/rules';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import { JumpToTarget, Rule, RuleType } from 'common/api/rules';`
         },
     ]
 });

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -36,6 +36,38 @@ import { JumpToTarget, Rule, RuleType } from 'common/api/rules';`,
             code: `
 import JumpToTarget, { Rule, RuleType } from 'common/api/rules';`,
         },
+        // don't modify sorting single line (without default)
+        {
+            code:
+                `
+import { a, b, c }                      from 'd';`
+        },
+        // don't modify sorting single line (with default)
+        {
+            code:
+                `
+import Deft, { a, b, c }                from 'd';`
+        },
+        // don't modify sorting multi line (without default)
+        {
+            code:
+                `
+import {
+    aItemLonger1,
+    bItemLonger1,
+    cItemLonger1,
+}                                       from 'd';`
+        }, ,
+        // don't modify sorting multi line (with default)
+        {
+            code:
+                `
+import Deft, {
+    aItemLonger1,
+    bItemLonger1,
+    cItemLonger1,
+}                                       from 'd';`
+        },
     ],
     invalid: [
         {
@@ -252,6 +284,58 @@ import {
             output:
                 `
 import { JumpToTarget, Rule, RuleType } from 'common/api/rules';`
+        },
+        // test sorting single line (without default)
+        {
+            code: `
+import {c, b, a}                        from 'd';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import { a, b, c }                      from 'd';`
+        },
+        // test sorting single line (with default)
+        {
+            code: `
+import Deft, {c, b, a}                  from 'd';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import Deft, { a, b, c }                from 'd';`
+        },
+        // test sorting multi line (without default)
+        {
+            code: `
+import {
+    cItemLonger1,
+    bItemLonger1,
+    aItemLonger1,
+}                                       from 'd';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import {
+    aItemLonger1,
+    bItemLonger1,
+    cItemLonger1,
+}                                       from 'd';`
+        }, ,
+        // test sorting multi line (with default)
+        {
+            code: `
+import Deft, {
+    cItemLonger1,
+    bItemLonger1,
+    aItemLonger1,
+}                                       from 'd';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import Deft, {
+    aItemLonger1,
+    bItemLonger1,
+    cItemLonger1,
+}                                       from 'd';`
         },
     ]
 });

--- a/lib/alignImports.test.js
+++ b/lib/alignImports.test.js
@@ -132,5 +132,73 @@ import {
     default as a,
 }                                       from 'somefile';`
         },
+        {
+            code: `
+import { Action } from 'common/api/exportImport/importContext';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import { Action }                       from 'common/api/exportImport/importContext';`
+        },
+        {
+            code: `
+import { expect }                       from 'chai';
+import Balances, { Balance }            from '/imports/api/balances';
+import {
+    createWorkinstruction,
+    originalCompany,
+    setupMain,
+    workinstructionToString,
+    approve,
+    getCreateWorkInstructionArgs,
+    exportWorkinstruction, selectCompany,
+    destinationCompany, actualImportWorkinstruction,
+    rootNodeId,
+    addWorkinstruction,
+    getDefaultContext,
+    importWorkinstruction,
+    getImportContext,
+}                                       from '/imports/api/workinstructions/server/export-import/importExportTestUtility';
+import { findRequiredBalance } from '/imports/api/workinstructions/server/export-import/importUtility';
+import uuid_v4 from '/imports/libs/uuid_v4';
+import { getMasterBalance } from '/imports/rest/v1/workinstructions/util';
+import { Action } from 'common/api/exportImport/importContext';
+import {
+    JumpToTarget,
+    Rule,
+    RuleType,
+} from 'common/api/rules';`,
+            errors: [{ line: 2, }],
+            output:
+                `
+import { expect }                       from 'chai';
+import Balances, { Balance }            from '/imports/api/balances';
+import {
+    createWorkinstruction,
+    originalCompany,
+    setupMain,
+    workinstructionToString,
+    approve,
+    getCreateWorkInstructionArgs,
+    exportWorkinstruction,
+    selectCompany,
+    destinationCompany,
+    actualImportWorkinstruction,
+    rootNodeId,
+    addWorkinstruction,
+    getDefaultContext,
+    importWorkinstruction,
+    getImportContext,
+}                                       from '/imports/api/workinstructions/server/export-import/importExportTestUtility';
+import { findRequiredBalance }          from '/imports/api/workinstructions/server/export-import/importUtility';
+import uuid_v4                          from '/imports/libs/uuid_v4';
+import { getMasterBalance }             from '/imports/rest/v1/workinstructions/util';
+import { Action }                       from 'common/api/exportImport/importContext';
+import {
+    JumpToTarget,
+    Rule,
+    RuleType,
+}                                       from 'common/api/rules';`
+        },
     ]
 });

--- a/lib/alignImportsTypescript.test.js
+++ b/lib/alignImportsTypescript.test.js
@@ -1,0 +1,74 @@
+const { createRuleTester } = require('./testUtils');
+const ruleTester = createRuleTester({}, true);
+const rule = require('./rules/align-imports');
+
+ruleTester.run('AlignImportsTypescript', rule, {
+    valid: [
+        {
+            code:
+                `
+import type { Parameters }              from '/imports/rest/v1/reporting/getRecordingAnswers';`,
+        },
+        {
+            code:
+                `
+import type { Parameters, Parans, Pas } from '/imports/rest/v1/reporting/getRecordingAnswers';`,
+        },
+        {
+            code:
+                `
+import type {
+    Parameters,
+    Parans,
+    Pasa,
+}                                       from '/imports/rest/v1/reporting/getRecordingAnswers';`,
+        },
+    ],
+    invalid: [
+        {
+            code:
+                `
+import type { Parameters }          from '/imports/rest/v1/reporting/getRecordingAnswers';`,
+            errors: [{
+                line: 2,
+            }],
+            output:
+                `
+import type { Parameters }              from '/imports/rest/v1/reporting/getRecordingAnswers';`
+        },
+        {
+            code:
+                `
+import type {
+    Parameters,
+    Params, 
+    Pas,
+}                                       from '/imports/rest/v1/reporting/getRecordingAnswers';`,
+            errors: [{
+                line: 2,
+            }],
+            output:
+                `
+import type { Parameters, Params, Pas } from '/imports/rest/v1/reporting/getRecordingAnswers';`,
+        },
+        {
+            code:
+                `
+import type {
+    Parameters,
+    Parans,
+    Pasa,
+}    from '/imports/rest/v1/reporting/getRecordingAnswers';`,
+            errors: [{
+                line: 2,
+            }],
+            output:
+                `
+import type {
+    Parameters,
+    Parans,
+    Pasa,
+}                                       from '/imports/rest/v1/reporting/getRecordingAnswers';`,
+        },
+    ]
+});

--- a/lib/rules/align-imports.js
+++ b/lib/rules/align-imports.js
@@ -1,110 +1,92 @@
 const DEFAULT_SOURCE_START_COLUMN = 45;
 const TAB_INDENT = 4;
-const spacingRegex = /[^\s](\s)+}/;
-const splitRegex = /([,{}]\s*)/g;
 
-// Get whitespace length before last curly brace of import statement;
-// >> import { Meteor   } from 'meteor';
-//                  >---<
-function getWhitespace(statement) {
-    let match = statement.match(spacingRegex);
-    if (match) {
-        return (match[0].length - 2) + 1;
-    }
-    return 1;
-}
-const longRegEx = /^import\s+(.*?)\s+from\s+(.*?);$/
-const importWithCurlyBracketsPart = /^import\s*{\s*(?<elements>.*)\s*}\s+from\s+(?<file>.*);$/gs;
-function splitSpecifiers(line, expectedFromPosition) {
-    if (line.indexOf('{') === -1) {
-        const result = longRegEx.exec(line);
-        // length 3 means there's a match (0 is the whole string, 1 is the first group, 2 is the second group)
-        if (result?.length === 3) {
-            return `import {\n${' '.repeat(TAB_INDENT)}default as ${result[1]},\n}${' '.repeat(expectedFromPosition - 1)}from ${result[2]};`;
-        }
-    }
-    // reset global regex
-    importWithCurlyBracketsPart.lastIndex = 0;
-    const resultPart1 = importWithCurlyBracketsPart.exec(line);
-    const elements = resultPart1?.groups?.elements;
-    const file = resultPart1?.groups?.file;
-    if (elements && file) {
-        const parts = elements.split(/[,\s]+/g).filter(p => p);
-        // TODO check if we want to sort
-        //parts.sort();
-        return `import {\n${parts.map((p) => ' '.repeat(TAB_INDENT) + p).join(',\n')},\n}${' '.repeat(expectedFromPosition - 1)}from ${file};`;
-    }
-}
-
-function importFixer(imports, sourceStartColumns, newSourceStartColumn, sourceCode) {
-
-    let isMultiLine = imports.map(decl => decl.loc.start.line !== decl.loc.end.line);
-    let hasFrom = imports.map(decl => decl.specifiers.length > 0);
-
-    // First column ends after specifiers or after import if no specifiers
-    let firstColumnEnds = imports.map((decl, i) => {
-        if (hasFrom[i]) {
-            if (isMultiLine[i]) {
-                let lastLineSource = sourceCode.lines[decl.loc.end.line - 1];
-                return lastLineSource.indexOf('}') + 1;
-            } else {
-                let lastSpecifier = decl.specifiers[decl.specifiers.length - 1];
-                let start = lastSpecifier.loc.end.column;
-
-                return start
-                    + (lastSpecifier.type === 'ImportSpecifier' ? getWhitespace(sourceCode.getText(decl)) : 0);
+function generateImportText(currentImport, defaultSpecifierText, specifierTexts, newSourceStartColumn, isMultiLine) {
+    let newLine = 'import ';
+    let shouldPrependComma = false;
+    if (defaultSpecifierText) {
+        if (newLine.length + defaultSpecifierText.length + 1 > newSourceStartColumn) {
+            if (!isMultiLine) {
+                return false;
             }
+            specifierTexts.unshift('default as ' + defaultSpecifierText);
         } else {
-            return 'import'.length;
-        }
-    });
-
-    // Second column starts before from or before source if no specifiers
-    let secondColumnStarts = sourceStartColumns.map((oldValue, i) => {
-        if (hasFrom[i]) {
-            oldValue -= 'from '.length;
-        }
-        return oldValue;
-    });
-
-    // Spacing between first column end and second column start should change this much
-    let deltas = sourceStartColumns.map(col => newSourceStartColumn - col);
-
-    //console.log('Is multiline       ', isMultiLine);
-    //console.log('First column end   ', firstColumnEnds);
-    //console.log('Second column start', secondColumnStarts);
-
-
-    return function* (fixer) {
-        for (let i = 0; i < imports.length; i++) {
-            let decl = imports[i];
-
-            const expectedFromPosition = newSourceStartColumn - 'from '.length;
-            // Split specifiers on different lines
-            if (firstColumnEnds[i] >= expectedFromPosition || isMultiLine[i]) {
-                let declText = sourceCode.getText(decl);
-                let newText = splitSpecifiers(declText, expectedFromPosition);
-                // Rule will rerun if alignment becomes incorrect
-                yield fixer.replaceTextRange(decl.range, newText);
-                continue;
-            }
-
-            let lineStart = isMultiLine[i] ?
-                sourceCode.getIndexFromLoc({ line: decl.loc.end.line, column: 0 })
-                : decl.range[0];
-
-            let oldSize = secondColumnStarts[i] - firstColumnEnds[i];
-            let newSize = oldSize + deltas[i];
-
-            let oldRange = [
-                lineStart + firstColumnEnds[i],
-                lineStart + secondColumnStarts[i]
-            ];
-
-            yield fixer.replaceTextRange(oldRange, ' '.repeat(newSize));
+            newLine += defaultSpecifierText;
+            shouldPrependComma = true;
         }
     }
+    if (specifierTexts.length > 0) {
+        if (shouldPrependComma) {
+            newLine += ',' + ' ';
+            shouldPrependComma = false;
+        }
+        newLine += '{' + (isMultiLine ? '\n' : ' ');
+        for (const specifierText of specifierTexts) {
+            if (isMultiLine) {
+                // prepend a tab
+                newLine += ' '.repeat(TAB_INDENT);
+            } else {
+                if (shouldPrependComma) {
+                    newLine += ', ';
+                } else {
+                    shouldPrependComma = true;
+                }
+            }
+            newLine += specifierText;
+            if (isMultiLine) {
+                // append a comma and new line
+                newLine += ',\n';
+            }
+        }
+        newLine += (isMultiLine ? '' : ' ') + '}';
+    }
 
+    if (isMultiLine) {
+        // repeat whitespace so that ' is on position <newSourceStartColumn>,
+        // subtract 5 characters for 'from ' and 1 for the curly brace
+        newLine += ' '.repeat(newSourceStartColumn - 5 - 1) + 'from ' + currentImport.source.raw + ';';
+        return newLine;
+    } else {
+        // 6 characters for ' from '
+        if (newLine.length + 6 <= newSourceStartColumn) {
+            // subtract 6 characters for ' from '
+            newLine += ' '.repeat(newSourceStartColumn - 6 - newLine.length);
+            newLine += ' from ' + currentImport.source.raw + ';';
+            return newLine;
+        }
+        return false;
+    }
+}
+
+function fixImport(currentImport, sourceCode, newSourceStartColumn) {
+    let defaultSpecifierText = '';
+    let specifierTexts = [];
+    for (const specifier of currentImport.specifiers) {
+        // the default specifier should be on the same line as the import
+        if (specifier.type === 'ImportDefaultSpecifier') {
+            defaultSpecifierText = sourceCode.getText(specifier);
+        }
+        // other specifiers should be aligned
+        else if (specifier.type === 'ImportSpecifier') {
+            specifierTexts.push(sourceCode.getText(specifier));
+        }
+    }
+    // first check if everything can be put on one line
+    let initialResult = generateImportText(currentImport, defaultSpecifierText, [...specifierTexts], newSourceStartColumn, false);
+    if (initialResult) {
+        return initialResult;
+    }
+    // if not, we will need to generate a multiple line import
+    return generateImportText(currentImport, defaultSpecifierText, [...specifierTexts], newSourceStartColumn, true);
+}
+
+function importFixer(incorrectImports, newSourceStartColumn, sourceCode) {
+    return function* (fixer) {
+        for (const incorrectImport of incorrectImports) {
+            const result = fixImport(incorrectImport, sourceCode, newSourceStartColumn);
+            yield fixer.replaceTextRange(incorrectImport.range, result);
+        }
+    }
 }
 
 
@@ -127,19 +109,66 @@ module.exports = {
         let imports = [];
         let done = false;
 
+        function importIsCorrect(currentImport) {
+            if (currentImport.specifiers.length === 0) {
+                return true;
+            }
+            if (currentImport.loc.start.line === currentImport.loc.end.line) {
+                return currentImport.source.loc.start.column === newSourceStartColumn;
+            }
+            else {
+                let specifierIndex = 0;
+                let defaultSpecifierLine = undefined;
+                let formattedLineLength = 7;//'import '
+                let hasNonDefault = false;
+                // in this case we have a multiline import
+                for (const specifier of currentImport.specifiers) {
+                    specifierIndex++;
+                    // the default specifier should be on the same line as the import
+                    if (specifier.type === 'ImportDefaultSpecifier') {
+                        if (specifier.loc.start.line !== currentImport.loc.start.line) {
+                            return false;
+                        }
+                        // default import should be on top
+                        if (specifierIndex !== 1) {
+                            return false;
+                        }
+                        defaultSpecifierLine = specifier.loc.start.line;
+                        formattedLineLength += specifier.loc.end.column - specifier.loc.start.column;
+                    }
+                    // other specifiers should be aligned
+                    else if (specifier.type === 'ImportSpecifier') {
+                        hasNonDefault = true;
+                        // first line after default should be on the line after the default
+                        // there should be no { on a separate line then
+                        if (defaultSpecifierLine && specifierIndex === 2) {
+                            if (specifier.loc.start.line !== defaultSpecifierLine + 1) {
+                                return false;
+                            }
+                        }
+                        if (specifier.loc.start.column !== TAB_INDENT) {
+                            return false;
+                        }
+                        formattedLineLength += specifier.loc.end.column - specifier.loc.start.column;
+                    }
+                }
+                if (hasNonDefault) {
+                    formattedLineLength += 4;// '{ ' and ' }'
+                }
+                formattedLineLength += (currentImport.specifiers.length - 1) * 2;//', '
+                formattedLineLength += 6;//' from ';
+                // when there's no way to format the imports correctly, return true
+                return formattedLineLength > newSourceStartColumn;
+            }
+        }
+
         function importsDone() {
-
-            const sourceStartColumns = imports.map(decl => decl.source.loc.start.column);
-            const hasUnalignedSpecifiers = imports.filter(decl =>
-                decl.specifiers.length > 1 &&
-                decl.specifiers.find(specifier => specifier.loc.start.column != TAB_INDENT)
-            ).length > 0;
-
-            if (!sourceStartColumns.every((col, i) => col === newSourceStartColumn) || hasUnalignedSpecifiers) {
+            const incorrectImports = imports.filter((currentImport) => !importIsCorrect(currentImport));
+            if (incorrectImports.length) {
                 context.report({
                     node: imports[0],
                     message: 'Imports not aligned correctly',
-                    fix: importFixer(imports, sourceStartColumns, newSourceStartColumn, context.getSourceCode())
+                    fix: importFixer(incorrectImports, newSourceStartColumn, context.getSourceCode())
                 });
             }
         }

--- a/lib/rules/align-imports.js
+++ b/lib/rules/align-imports.js
@@ -4,6 +4,9 @@ const TAB_INDENT = 4;
 function generateImportText(currentImport, defaultSpecifierText, importNamespaceSpecifierText,
     specifierTexts, newSourceStartColumn, isMultiLine) {
     let newLine = 'import ';
+    if (currentImport.importKind && currentImport.importKind === 'type') {
+        newLine += 'type ';
+    }
     // when there's an import namespace, we'll only have that
     if (importNamespaceSpecifierText) {
         newLine += importNamespaceSpecifierText;
@@ -167,6 +170,9 @@ module.exports = {
                 let defaultSpecifierLine = undefined;
                 let formattedLineLength = 7;//'import '
                 let hasNonDefault = false;
+                if (currentImport.importKind && currentImport.importKind === 'type') {
+                    formattedLineLength += 5;//'type '
+                }
                 // in this case we have a multiline import
                 for (const specifier of currentImport.specifiers) {
                     specifierIndex++;

--- a/lib/rules/align-imports.js
+++ b/lib/rules/align-imports.js
@@ -14,6 +14,7 @@ function getWhitespace(statement) {
     return 1;
 }
 const longRegEx = /^import\s+(.*)\s+from\s+(.*);$/
+const importWithCurlyBracketsPart = /^import\s*{\s*(?<elements>.*)\s*}\s+from\s+(?<file>.*);$/gs;
 function splitSpecifiers(line, expectedFromPosition) {
     if (line.indexOf('{') === -1) {
         const result = longRegEx.exec(line);
@@ -22,15 +23,17 @@ function splitSpecifiers(line, expectedFromPosition) {
             return `import {\n${' '.repeat(TAB_INDENT)}default as ${result[1]},\n}${' '.repeat(expectedFromPosition - 1)}from ${result[2]};`;
         }
     }
-    return line.replace(splitRegex, (char) => {
-        switch (char[0]) {
-            case '{':
-            case ',':
-                return char + '\n' + ' '.repeat(TAB_INDENT);
-            case '}':
-                return '\n} ';
-        }
-    });
+    // reset global regex
+    importWithCurlyBracketsPart.lastIndex = 0;
+    const resultPart1 = importWithCurlyBracketsPart.exec(line);
+    const elements = resultPart1?.groups?.elements;
+    const file = resultPart1?.groups?.file;
+    if (elements && file) {
+        const parts = elements.split(/[,\s]+/g).filter(p => p);
+        // TODO check if we want to sort
+        //parts.sort();
+        return `import {\n${parts.map((p) => ' '.repeat(TAB_INDENT) + p).join(',\n')},\n}${' '.repeat(expectedFromPosition - 1)}from ${file};`;
+    }
 }
 
 function importFixer(imports, sourceStartColumns, newSourceStartColumn, sourceCode) {
@@ -78,7 +81,7 @@ function importFixer(imports, sourceStartColumns, newSourceStartColumn, sourceCo
 
             const expectedFromPosition = newSourceStartColumn - 'from '.length;
             // Split specifiers on different lines
-            if (firstColumnEnds[i] >= expectedFromPosition) {
+            if (firstColumnEnds[i] >= expectedFromPosition || isMultiLine[i]) {
                 let declText = sourceCode.getText(decl);
                 let newText = splitSpecifiers(declText, expectedFromPosition);
                 // Rule will rerun if alignment becomes incorrect
@@ -127,8 +130,12 @@ module.exports = {
         function importsDone() {
 
             const sourceStartColumns = imports.map(decl => decl.source.loc.start.column);
+            const hasUnalignedSpecifiers = imports.filter(decl =>
+                decl.specifiers.length > 1 &&
+                decl.specifiers.find(specifier => specifier.loc.start.column != TAB_INDENT)
+            ).length > 0;
 
-            if (!sourceStartColumns.every((col, i) => col === newSourceStartColumn)) {
+            if (!sourceStartColumns.every((col, i) => col === newSourceStartColumn) || hasUnalignedSpecifiers) {
                 context.report({
                     node: imports[0],
                     message: 'Imports not aligned correctly',

--- a/lib/rules/align-imports.js
+++ b/lib/rules/align-imports.js
@@ -86,7 +86,7 @@ function importFixer(imports, sourceStartColumns, newSourceStartColumn, sourceCo
                 let newText = splitSpecifiers(declText, expectedFromPosition);
                 // Rule will rerun if alignment becomes incorrect
                 yield fixer.replaceTextRange(decl.range, newText);
-                return;
+                continue;
             }
 
             let lineStart = isMultiLine[i] ?

--- a/lib/rules/align-imports.js
+++ b/lib/rules/align-imports.js
@@ -1,44 +1,55 @@
 const DEFAULT_SOURCE_START_COLUMN = 45;
 const TAB_INDENT = 4;
 
-function generateImportText(currentImport, defaultSpecifierText, specifierTexts, newSourceStartColumn, isMultiLine) {
+function generateImportText(currentImport, defaultSpecifierText, importNamespaceSpecifierText,
+    specifierTexts, newSourceStartColumn, isMultiLine) {
     let newLine = 'import ';
-    let shouldPrependComma = false;
-    if (defaultSpecifierText) {
-        if (newLine.length + defaultSpecifierText.length + 1 > newSourceStartColumn) {
-            if (!isMultiLine) {
-                return false;
-            }
-            specifierTexts.unshift('default as ' + defaultSpecifierText);
-        } else {
-            newLine += defaultSpecifierText;
-            shouldPrependComma = true;
+    // when there's an import namespace, we'll only have that
+    if (importNamespaceSpecifierText) {
+        newLine += importNamespaceSpecifierText;
+        shouldPrependComma = true;
+        if (isMultiLine) {
+            throw new Error('Import namespace specifier not supported in multi line imports');
         }
     }
-    if (specifierTexts.length > 0) {
-        if (shouldPrependComma) {
-            newLine += ',' + ' ';
-            shouldPrependComma = false;
-        }
-        newLine += '{' + (isMultiLine ? '\n' : ' ');
-        for (const specifierText of specifierTexts) {
-            if (isMultiLine) {
-                // prepend a tab
-                newLine += ' '.repeat(TAB_INDENT);
+    else {
+        let shouldPrependComma = false;
+        if (defaultSpecifierText) {
+            if (newLine.length + defaultSpecifierText.length + 1 > newSourceStartColumn) {
+                if (!isMultiLine) {
+                    return false;
+                }
+                specifierTexts.unshift('default as ' + defaultSpecifierText);
             } else {
-                if (shouldPrependComma) {
-                    newLine += ', ';
+                newLine += defaultSpecifierText;
+                shouldPrependComma = true;
+            }
+        }
+        if (specifierTexts.length > 0) {
+            if (shouldPrependComma) {
+                newLine += ',' + ' ';
+                shouldPrependComma = false;
+            }
+            newLine += '{' + (isMultiLine ? '\n' : ' ');
+            for (const specifierText of specifierTexts) {
+                if (isMultiLine) {
+                    // prepend a tab
+                    newLine += ' '.repeat(TAB_INDENT);
                 } else {
-                    shouldPrependComma = true;
+                    if (shouldPrependComma) {
+                        newLine += ', ';
+                    } else {
+                        shouldPrependComma = true;
+                    }
+                }
+                newLine += specifierText;
+                if (isMultiLine) {
+                    // append a comma and new line
+                    newLine += ',\n';
                 }
             }
-            newLine += specifierText;
-            if (isMultiLine) {
-                // append a comma and new line
-                newLine += ',\n';
-            }
+            newLine += (isMultiLine ? '' : ' ') + '}';
         }
-        newLine += (isMultiLine ? '' : ' ') + '}';
     }
 
     if (isMultiLine) {
@@ -47,13 +58,18 @@ function generateImportText(currentImport, defaultSpecifierText, specifierTexts,
         newLine += ' '.repeat(newSourceStartColumn - 5 - 1) + 'from ' + currentImport.source.raw + ';';
         return newLine;
     } else {
+        // when it fits or when it's an import namespace => generate
         // 6 characters for ' from '
-        if (newLine.length + 6 <= newSourceStartColumn) {
+        if (newLine.length + 6 <= newSourceStartColumn || importNamespaceSpecifierText) {
             // subtract 6 characters for ' from '
-            newLine += ' '.repeat(newSourceStartColumn - 6 - newLine.length);
+            const whitespacesToAdd = newSourceStartColumn - 6 - newLine.length;
+            if (whitespacesToAdd > 0) {
+                newLine += ' '.repeat(whitespacesToAdd);
+            }
             newLine += ' from ' + currentImport.source.raw + ';';
             return newLine;
         }
+        // no import namespace and no fit
         return false;
     }
 }
@@ -61,10 +77,14 @@ function generateImportText(currentImport, defaultSpecifierText, specifierTexts,
 function fixImport(currentImport, sourceCode, newSourceStartColumn) {
     let defaultSpecifierText = '';
     let specifierTexts = [];
+    let importNamespaceSpecifierText = '';
     for (const specifier of currentImport.specifiers) {
         // the default specifier should be on the same line as the import
         if (specifier.type === 'ImportDefaultSpecifier') {
             defaultSpecifierText = sourceCode.getText(specifier);
+        }
+        else if (specifier.type === 'ImportNamespaceSpecifier') {
+            importNamespaceSpecifierText = sourceCode.getText(specifier);
         }
         // other specifiers should be aligned
         else if (specifier.type === 'ImportSpecifier') {
@@ -74,12 +94,14 @@ function fixImport(currentImport, sourceCode, newSourceStartColumn) {
     // rearrange order of the specifiers
     specifierTexts.sort();
     // first check if everything can be put on one line
-    let initialResult = generateImportText(currentImport, defaultSpecifierText, [...specifierTexts], newSourceStartColumn, false);
+    let initialResult = generateImportText(currentImport, defaultSpecifierText, importNamespaceSpecifierText,
+        [...specifierTexts], newSourceStartColumn, false);
     if (initialResult) {
         return initialResult;
     }
     // if not, we will need to generate a multiple line import
-    return generateImportText(currentImport, defaultSpecifierText, [...specifierTexts], newSourceStartColumn, true);
+    return generateImportText(currentImport, defaultSpecifierText, importNamespaceSpecifierText,
+        [...specifierTexts], newSourceStartColumn, true);
 }
 
 function importFixer(incorrectImports, newSourceStartColumn, sourceCode) {
@@ -117,6 +139,23 @@ module.exports = {
             }
             if (currentImport.loc.start.line === currentImport.loc.end.line) {
                 if (currentImport.source.loc.start.column !== newSourceStartColumn) {
+                    if (currentImport.specifiers.length === 1 &&
+                        currentImport.specifiers[0].type === 'ImportNamespaceSpecifier') {
+                        // when only having a namespace specifier, check if it could theoretically fit
+                        const loc = currentImport.specifiers[0].loc;
+                        let size = loc.end.column - loc.start.column;
+                        // 'import ': 7
+                        // ' from ': 6
+                        if (size + 7 + 6 <= newSourceStartColumn) {
+                            return false;
+                        }
+                        // don't format import namespace when they are too large
+                        // unless there are too many whitespaces
+                        const currentSize = currentImport.loc.end.column - currentImport.loc.start.column;
+                        const sourceSize = currentImport.source.loc.end.column - currentImport.source.loc.start.column;
+                        const optimalSize = 7 + 6 + size + sourceSize + 1;// 'import ' & 'from ' & ';'
+                        return currentSize === optimalSize;
+                    }
                     return false;
                 }
             }
@@ -129,7 +168,11 @@ module.exports = {
                 for (const specifier of currentImport.specifiers) {
                     specifierIndex++;
                     // the default specifier should be on the same line as the import
-                    if (specifier.type === 'ImportDefaultSpecifier') {
+                    if (specifier.type === 'ImportDefaultSpecifier' || specifier.type === 'ImportNamespaceSpecifier') {
+                        if (specifierIndex !== 1) {
+                            // should be first line
+                            return false;
+                        }
                         if (specifier.loc.start.line !== currentImport.loc.start.line) {
                             return false;
                         }
@@ -165,14 +208,8 @@ module.exports = {
             // now verify alphabetical order
             let previousSpecifier = undefined;
             for (const specifier of currentImport.specifiers) {
-                if (specifier.type === 'ImportDefaultSpecifier') {
-                    if (previousSpecifier !== undefined) {
-                        // default import should be on top
-                        return false;
-                    }
-                }
-                // other specifiers should be aligned
-                else if (specifier.type === 'ImportSpecifier') {
+                // normal specifiers should be aligned
+                if (specifier.type === 'ImportSpecifier') {
                     hasNonDefault = true;
                     const newSpecifier = sourceCode.getText(specifier);
                     if (previousSpecifier && newSpecifier < previousSpecifier) {

--- a/lib/rules/align-imports.js
+++ b/lib/rules/align-imports.js
@@ -133,10 +133,6 @@ module.exports = {
                         if (specifier.loc.start.line !== currentImport.loc.start.line) {
                             return false;
                         }
-                        // default import should be on top
-                        if (specifierIndex !== 1) {
-                            return false;
-                        }
                         defaultSpecifierLine = specifier.loc.start.line;
                         formattedLineLength += specifier.loc.end.column - specifier.loc.start.column;
                     }
@@ -171,10 +167,9 @@ module.exports = {
             for (const specifier of currentImport.specifiers) {
                 if (specifier.type === 'ImportDefaultSpecifier') {
                     if (previousSpecifier !== undefined) {
-                        // default should always be first
+                        // default import should be on top
                         return false;
                     }
-                    previousSpecifier = sourceCode.getText(specifier);
                 }
                 // other specifiers should be aligned
                 else if (specifier.type === 'ImportSpecifier') {

--- a/lib/rules/align-imports.js
+++ b/lib/rules/align-imports.js
@@ -13,7 +13,7 @@ function getWhitespace(statement) {
     }
     return 1;
 }
-const longRegEx = /^import\s+(.*)\s+from\s+(.*);$/
+const longRegEx = /^import\s+(.*?)\s+from\s+(.*?);$/
 const importWithCurlyBracketsPart = /^import\s*{\s*(?<elements>.*)\s*}\s+from\s+(?<file>.*);$/gs;
 function splitSpecifiers(line, expectedFromPosition) {
     if (line.indexOf('{') === -1) {

--- a/lib/rules/align-imports.js
+++ b/lib/rules/align-imports.js
@@ -160,6 +160,9 @@ module.exports = {
                 }
             }
             else {
+                if (currentImport.source.loc.start.column !== newSourceStartColumn) {
+                    return false;
+                }
                 let specifierIndex = 0;
                 let defaultSpecifierLine = undefined;
                 let formattedLineLength = 7;//'import '

--- a/lib/rules/align-imports.js
+++ b/lib/rules/align-imports.js
@@ -71,6 +71,8 @@ function fixImport(currentImport, sourceCode, newSourceStartColumn) {
             specifierTexts.push(sourceCode.getText(specifier));
         }
     }
+    // rearrange order of the specifiers
+    specifierTexts.sort();
     // first check if everything can be put on one line
     let initialResult = generateImportText(currentImport, defaultSpecifierText, [...specifierTexts], newSourceStartColumn, false);
     if (initialResult) {
@@ -109,12 +111,14 @@ module.exports = {
         let imports = [];
         let done = false;
 
-        function importIsCorrect(currentImport) {
+        function importIsCorrect(currentImport, sourceCode) {
             if (currentImport.specifiers.length === 0) {
                 return true;
             }
             if (currentImport.loc.start.line === currentImport.loc.end.line) {
-                return currentImport.source.loc.start.column === newSourceStartColumn;
+                if (currentImport.source.loc.start.column !== newSourceStartColumn) {
+                    return false;
+                }
             }
             else {
                 let specifierIndex = 0;
@@ -158,12 +162,35 @@ module.exports = {
                 formattedLineLength += (currentImport.specifiers.length - 1) * 2;//', '
                 formattedLineLength += 6;//' from ';
                 // when there's no way to format the imports correctly, return true
-                return formattedLineLength > newSourceStartColumn;
+                if (formattedLineLength <= newSourceStartColumn) {
+                    return false;
+                }
             }
+            // now verify alphabetical order
+            let previousSpecifier = undefined;
+            for (const specifier of currentImport.specifiers) {
+                if (specifier.type === 'ImportDefaultSpecifier') {
+                    if (previousSpecifier !== undefined) {
+                        // default should always be first
+                        return false;
+                    }
+                    previousSpecifier = sourceCode.getText(specifier);
+                }
+                // other specifiers should be aligned
+                else if (specifier.type === 'ImportSpecifier') {
+                    hasNonDefault = true;
+                    const newSpecifier = sourceCode.getText(specifier);
+                    if (previousSpecifier && newSpecifier < previousSpecifier) {
+                        return false;
+                    }
+                    previousSpecifier = newSpecifier;
+                }
+            }
+            return true;
         }
 
         function importsDone() {
-            const incorrectImports = imports.filter((currentImport) => !importIsCorrect(currentImport));
+            const incorrectImports = imports.filter((currentImport) => !importIsCorrect(currentImport, context.getSourceCode()));
             if (incorrectImports.length) {
                 context.report({
                     node: imports[0],

--- a/lib/testUtils.js
+++ b/lib/testUtils.js
@@ -33,10 +33,11 @@ class TestingLibraryRuleTester extends RuleTester {
 }
 
 exports.createRuleTester = (
-    parserOptions = {}
+    parserOptions = {},
+    isTypescript = false,
 ) => {
     return new TestingLibraryRuleTester({
-        parser: resolve('./node_modules/@babel/eslint-parser'),
+        parser: isTypescript ? resolve('./node_modules/@typescript-eslint/parser/dist') : resolve('./node_modules/@babel/eslint-parser'),
         parserOptions: {
             ecmaVersion: 2018,
             sourceType: 'module',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-azumuta",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-azumuta",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.10",
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@babel/core": "^7.11.4",
         "@babel/eslint-parser": "^7.11.4",
+        "@typescript-eslint/parser": "^6.9.0",
         "@babel/plugin-proposal-class-properties": "^7.10.4",
         "@babel/plugin-proposal-decorators": "^7.10.5",
         "@babel/plugin-proposal-do-expressions": "^7.10.4",
@@ -2511,11 +2512,151 @@
         "eslint-scope": "5.1.1"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "peer": true
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
+      "integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.9.0",
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/typescript-estree": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
+      "integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
+      "integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
+      "integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
+      "integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.9.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -2632,6 +2773,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/array.prototype.findlastindex": {
@@ -2814,7 +2963,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -3161,6 +3309,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -3584,6 +3743,21 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3593,6 +3767,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "5.0.1",
@@ -3609,7 +3791,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3840,6 +4021,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gopd": {
@@ -4136,7 +4344,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4396,6 +4603,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/minimatch": {
@@ -4795,6 +5022,14 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -4814,7 +5049,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -4845,6 +5079,25 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -5007,6 +5260,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -5016,6 +5278,28 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -5138,6 +5422,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/slice-ansi": {
@@ -5344,12 +5636,22 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -5467,6 +5769,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       "devDependencies": {
         "@babel/core": "^7.11.4",
         "@babel/eslint-parser": "^7.11.4",
-        "@typescript-eslint/parser": "^6.9.0",
         "@babel/plugin-proposal-class-properties": "^7.10.4",
         "@babel/plugin-proposal-decorators": "^7.10.5",
         "@babel/plugin-proposal-do-expressions": "^7.10.4",
@@ -37,6 +36,7 @@
         "@babel/plugin-transform-typescript": "^7.11.0",
         "@babel/preset-env": "^7.11.0",
         "@babel/preset-react": "^7.10.4",
+        "@typescript-eslint/parser": "^6.9.0",
         "chai": "^4.3.10",
         "eslint": "~7.6.0",
         "mocha": "^10.2.0"
@@ -2516,6 +2516,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -2528,6 +2529,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2536,6 +2538,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -2554,6 +2557,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
       "integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
+      "dev": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.9.0",
         "@typescript-eslint/types": "6.9.0",
@@ -2581,6 +2585,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
       "integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "6.9.0",
         "@typescript-eslint/visitor-keys": "6.9.0"
@@ -2597,6 +2602,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
       "integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+      "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -2609,6 +2615,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
       "integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "6.9.0",
         "@typescript-eslint/visitor-keys": "6.9.0",
@@ -2635,6 +2642,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
       "integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "6.9.0",
         "eslint-visitor-keys": "^3.4.1"
@@ -2651,6 +2659,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2779,6 +2788,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2963,6 +2973,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -3315,6 +3326,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -3747,6 +3759,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3772,6 +3785,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -3791,6 +3805,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -4027,6 +4042,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -4046,6 +4062,7 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4344,6 +4361,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4609,6 +4627,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -4617,6 +4636,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -5026,6 +5046,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5049,6 +5070,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -5084,6 +5106,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5264,6 +5287,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -5284,6 +5308,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5428,6 +5453,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5636,6 +5662,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -5647,6 +5674,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
       "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "dev": true,
       "engines": {
         "node": ">=16.13.0"
       },
@@ -5775,6 +5803,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@babel/core": "^7.11.4",
     "@babel/eslint-parser": "^7.11.4",
+    "@typescript-eslint/parser": "^6.9.0",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/plugin-proposal-decorators": "^7.10.5",
     "@babel/plugin-proposal-do-expressions": "^7.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-azumuta",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Enforce Azumuta style rules for imports",
   "keywords": [
     "eslint",


### PR DESCRIPTION
fixes DEV-1377

Warning: with these changes, the imported functions etc are sorted, we might also try to make the imports more compact, ...


To test:
npm un eslint-plugin-azumuta
npm i ../eslint-plugin-azumuta

Should apply this renaming in one commit to avoid pull requests with formatting changes